### PR TITLE
feat: support browser search engine feature with q=%s

### DIFF
--- a/favicon/opensearch.xml
+++ b/favicon/opensearch.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/">
+  <ShortName>Commander Spellbook</ShortName>
+  <Description>Search Commander Spellbook by name</Description>
+  <Image width="32" height="32" type="image/x-icon">https://commanderspellbook.com/favicon/favicon-32x32.png</Image>
+  <Tags>Commander Spellbook - Combo Database for Commander (EDH)</Tags>
+  <InputEncoding>UTF-8</InputEncoding>
+  <Url method="get" rel="results" type="text/html" template="https://commanderspellbook.com/?q={searchTerms}" />
+  <Url rel="self" type="application/opensearchdescription+xml" template="https://commanderspellbook.com/favicon/opensearch.xml" />
+  <Language>en</Language>
+  <InputEncoding>UTF-8</InputEncoding>
+</OpenSearchDescription>

--- a/index.html
+++ b/index.html
@@ -10,6 +10,7 @@
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
   <meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="search" type="application/opensearchdescription+xml" title="Commander Spellbook" href="https://commanderspellbook.com/favicon/opensearch.xml" />
 
   <!--Favicon-->
   <link rel="apple-touch-icon" sizes="180x180" href="favicon/apple-touch-icon.png">

--- a/js/combos.js
+++ b/js/combos.js
@@ -70,6 +70,10 @@ function linkToCombo() {
         const searchInput = document.getElementById('card-input');
         searchInput.setAttribute('value', "banned");
         evaluateSearchQuery(true);
+    } else if (qs.q !== undefined) {
+        const searchInput = document.getElementById('card-input');
+        searchInput.setAttribute('value', qs.q);
+        evaluateSearchQuery(true);
     }
 }
 


### PR DESCRIPTION
Added support for `?q=%s` and [OpenSearch manifest](https://developer.mozilla.org/en-US/docs/Web/OpenSearch).

**Note**: I wasn't sure where to store the manifest so I just put it in the favicon folder, I can move it if needed