### PR TITLE
fix: properly display combo count when filtering

### DIFF
--- a/js/combos.js
+++ b/js/combos.js
@@ -370,12 +370,14 @@ function updateTableWithCombos(combos) {
 }
 
 // Filter by Search Input
-function filterCombos(comboCount) {
-    $("#combos tr").filter(function () {
-        $(this).toggle(inIdentity($(this)) && numberOfCards($(this)));
-    });
+function filterCombos() {
+    const results = $("#combos tr").filter(function () {
+        const shouldToggle = inIdentity($(this)) && numberOfCards($(this));
+        $(this).toggle(shouldToggle);
+        return shouldToggle;
+    }).length;
 
-    document.getElementById('card-input-results').innerHTML = `${comboCount} Results`;
+    document.getElementById('card-input-results').innerHTML = `${results} Results`;
 
     tableStriping();
 }


### PR DESCRIPTION
Hi,

I noticed that when you filter by mana or card quantity the result count says undefined.

This fixes the issue. It's not using comboCount anymore (which was undefined while filtering), but instead is using the count coming back from the filter you were already doing to populate the result count