### PR TITLE
feat: add spinner while loading large combo datasets

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -144,6 +144,20 @@ tbody tr {
     font-size: 14px;
 }
 
+tfoot {
+    background: #EEEEEE;
+}
+
+tfoot.hidden {
+    display: none;
+}
+
+/* using id to increase specificity of css selector */
+tfoot#loading-spinner tr td {
+    padding-top: 1.5rem;
+    padding-bottom: 1.5rem;
+}
+
 tbody tr:nth-child(odd) {
     background-color: #EEEEEE;
 }

--- a/index.html
+++ b/index.html
@@ -265,6 +265,27 @@
         </tr>
       </thead>
       <tbody id="combos"></tbody>
+      <tfoot id="loading-spinner" class="hidden">
+        <tr>
+          <td colspan="6" class="text-center">
+            <div class="spinner-grow text-warning" role="status">
+              <span class="sr-only">Loading...</span>
+            </div>
+            <div class="spinner-grow text-primary" role="status">
+              <span class="sr-only">Loading...</span>
+            </div>
+            <div class="spinner-grow text-secondary" role="status">
+              <span class="sr-only">Loading...</span>
+            </div>
+            <div class="spinner-grow text-danger" role="status">
+              <span class="sr-only">Loading...</span>
+            </div>
+            <div class="spinner-grow text-success" role="status">
+              <span class="sr-only">Loading...</span>
+            </div>
+          </td>
+        </tr>
+      </tfoot>
     </table>
   </div>
 

--- a/js/combos.js
+++ b/js/combos.js
@@ -371,15 +371,24 @@ function updateTableWithCombos(combos) {
 
 // Filter by Search Input
 function filterCombos() {
-    const results = $("#combos tr").filter(function () {
-        const shouldToggle = inIdentity($(this)) && numberOfCards($(this));
-        $(this).toggle(shouldToggle);
-        return shouldToggle;
-    }).length;
+    $("#combos").hide();
+    $("#loading-spinner").removeClass('hidden');
 
-    document.getElementById('card-input-results').innerHTML = `${results} Results`;
+    setTimeout(function() {
+        // The setTimeout is needed to give the browser a chance to re-render the page so the spinner shows up
+        const results = $("#combos tr").filter(function () {
+            const shouldToggle = inIdentity($(this)) && numberOfCards($(this));
+            $(this).toggle(shouldToggle);
+            return shouldToggle;
+        }).length;
 
-    tableStriping();
+        $("#combos").show();
+        $("#loading-spinner").addClass('hidden');
+
+        document.getElementById('card-input-results').innerHTML = `${results} Results`;
+
+        tableStriping();
+    }, 0);
 }
 
 // Filter by Color Identity
@@ -464,7 +473,7 @@ function numberOfCards(context) {
 
 // Re-apply table striping on search
 function tableStriping() {
-    $("tr:visible").each(function (index) {
+    $("#combos tr:visible").each(function (index) {
         $(this).css("background-color", !!(index & 1) ? "rgba(0,0,0,.05)" : "rgba(0,0,0,0)");
     });
 }


### PR DESCRIPTION
I noticed while searching for 'retreat to coralhelm' combos and filtering by card quantity the UI would get stuck while hiding/showing the thousands of rows that it needed to change.

I've added a spinner while this happens which makes the UI feel snappier

**Mobile screenshot:**
![image](https://user-images.githubusercontent.com/179976/94847055-eed8c380-03d6-11eb-8b30-9c5cc1d81a70.png)

**Desktop Screenshot:**
![image](https://user-images.githubusercontent.com/179976/94847129-0617b100-03d7-11eb-81f7-a6afe8842f49.png)
